### PR TITLE
Added Support for Name Matching

### DIFF
--- a/js/wizard.js
+++ b/js/wizard.js
@@ -356,10 +356,10 @@
 
 			if (selectedItem) {
 				step = selectedItem.step || -1;
-				$matchedByName = this.$element.find('.steps').filter('[data-name="'+step+'"]');
+				$matchedByName = this.$element.find('.steps li').filter('[data-name="'+step+'"]');
 
-				if (isNaN(step) && $matchedByName.length() >0){
-					matchedStep = $matchedByName.get(0).attr('data-step');
+				if (isNaN(step) && $matchedByName.length){
+					matchedStep = $matchedByName.first.attr('data-step');
 					this.currentStep = matchedStep;
 					this.setState();
 				} else if (step >= 1 && step <= this.numSteps) {


### PR DESCRIPTION
Added Support to change Steps by step data-name

Example Usage
Given 
&lt; li data-name="abc" data-step="2" &gt;

.wizard("selectedItem", {step: "abc"});
