### PR TITLE
Ability to Match selectedItem steps by Data-name

### DIFF
--- a/js/wizard.js
+++ b/js/wizard.js
@@ -356,10 +356,10 @@
 
 			if (selectedItem) {
 				step = selectedItem.step || -1;
-				$matchedByName = this.$element.find('.steps').filter('[data-name="'+step+'"]');
+				$matchedByName = this.$element.find('.steps li').filter('[data-name="'+step+'"]');
 
-				if (isNaN(step) && $matchedByName.length() >0){
-					matchedStep = $matchedByName.get(0).attr('data-step');
+				if (isNaN(step) && $matchedByName.length){
+					matchedStep = $matchedByName.first().attr('data-step');
 					this.currentStep = matchedStep;
 					this.setState();
 				} else if (step >= 1 && step <= this.numSteps) {


### PR DESCRIPTION
Added the ability to enter a text string to match against data-name attribute in selectedItem api.

&lt;li data-name="abc1" data-step="1"&gt;
&lt;li data-name="abc2" data-step="2"&gt;

.wizard("selectedItem", {step: "abc2"});
.wizard("selectedItem", {step: 2});
.wizard("selectedItem", {step: "2"});
